### PR TITLE
Fix flags used by make

### DIFF
--- a/make
+++ b/make
@@ -3,9 +3,9 @@ SCRIPTABS=$(readlink -f $0)
 SCRIPTPATH=`dirname $SCRIPTABS`
 SCRIPT=`basename $0`
 
-export CFLAGS="-march=i486 -mtune=i686 -0s -pipe"
-export CXXFLAGS="-march=i486 -mtune=i686 -0s -pipe"
-export LDFLAGS="-W1,-O1"
+export CFLAGS="-march=i486 -mtune=i686 -Os -pipe"
+export CXXFLAGS="-march=i486 -mtune=i686 -Os -pipe"
+export LDFLAGS="-Wl,-O1"
 
 if [ -z "$1" ]
 then


### PR DESCRIPTION
There is no `-0s` (zero) flag, bu there is `-Os`.
There is no `-W1` (one) flag, but there is `-Wl`.
